### PR TITLE
Add Shroom blocks + worldgen

### DIFF
--- a/src/main/java/com/github/turtlelabsmc/reverie/Reverie.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/Reverie.java
@@ -1,9 +1,14 @@
 package com.github.turtlelabsmc.reverie;
 
 import com.github.turtlelabsmc.reverie.event.EventManager;
+import com.github.turtlelabsmc.reverie.registry.FeatureRegistry;
+import com.github.turtlelabsmc.reverie.registry.ReverieObjects;
 import com.github.turtlelabsmc.reverie.registry.PotionRegistry;
 import com.github.turtlelabsmc.reverie.registry.StatusEffectRegistry;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,6 +16,9 @@ import org.apache.logging.log4j.Logger;
 public class Reverie implements ModInitializer
 {
     public static final Logger LOGGER = LogManager.getLogger();
+    public static final String MODID = "reverie";
+    public static final ItemGroup ITEM_GROUP = FabricItemGroupBuilder.build(new Identifier(MODID, MODID), () -> new ItemStack(ReverieObjects.SHROOM));
+
     @Override
     public void onInitialize()
     {
@@ -19,10 +27,12 @@ public class Reverie implements ModInitializer
 
         PotionRegistry.register();
         StatusEffectRegistry.register();
+        ReverieObjects.register();
+        FeatureRegistry.register();
     }
 
     public static Identifier modId(String path)
     {
-        return new Identifier("reverie", path);
+        return new Identifier(MODID, path);
     }
 }

--- a/src/main/java/com/github/turtlelabsmc/reverie/block/ShroomBlock.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/block/ShroomBlock.java
@@ -1,0 +1,51 @@
+package com.github.turtlelabsmc.reverie.block;
+
+import com.github.turtlelabsmc.reverie.Reverie;
+import com.github.turtlelabsmc.reverie.registry.ReverieObjects;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PlantBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.IntProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+
+import java.util.Random;
+
+public class ShroomBlock extends PlantBlock {
+
+    public static final IntProperty AGE;
+//    public static final BooleanProperty WARPED = BooleanProperty.of("warped");
+
+    public ShroomBlock(Settings settings) {
+        super(settings);
+        this.setDefaultState(this.stateManager.getDefaultState().with(AGE, 0));
+    }
+
+    public boolean canPlantOnTop(BlockState floor, BlockView world, BlockPos pos) {
+        return floor.isIn(BlockTags.NYLIUM);
+    }
+
+    public boolean hasRandomTicks(BlockState state) {
+        return (Integer)state.get(AGE) < 3;
+    }
+
+    public ItemStack getPickStack(BlockView world, BlockPos pos, BlockState state) {
+        return new ItemStack(ReverieObjects.SHROOM);
+    }
+
+    protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
+        stateManager.add(AGE);
+    }
+
+    static {
+        AGE = Properties.AGE_3;
+    }
+}

--- a/src/main/java/com/github/turtlelabsmc/reverie/features/ShroomFeature.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/features/ShroomFeature.java
@@ -1,0 +1,101 @@
+package com.github.turtlelabsmc.reverie.features;
+
+import com.github.turtlelabsmc.reverie.block.ShroomBlock;
+import com.github.turtlelabsmc.reverie.registry.ReverieObjects;
+import com.mojang.serialization.Codec;
+import net.minecraft.block.AbstractPlantStemBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+import java.util.Random;
+
+public class ShroomFeature extends Feature<DefaultFeatureConfig> {
+    public ShroomFeature(Codec<DefaultFeatureConfig> config) {
+        super(config);
+    }
+
+    @Override
+    public boolean generate(FeatureContext<DefaultFeatureConfig> ctx) {
+        StructureWorldAccess world = ctx.getWorld();
+        System.out.println("HEY   ->   " + ctx.getOrigin().toShortString());
+        Random random = ctx.getRandom();
+
+        // Go up from the origin, roll dice, generate if dice rolled
+
+        BlockPos.Mutable mutable = ctx.getOrigin().mutableCopy();
+        for (int i=0; i<256; i++) {
+            mutable.move(Direction.UP);
+            if (canGenerate(world, mutable) && !isNotSuitable(world, mutable)) {
+                if (random.nextInt(6) == 0) {
+                    generateShroom(world, random, mutable, 0, 1); // 20% roll
+                }
+            }
+        }
+
+        BlockPos topPos = world.getTopPosition(Heightmap.Type.WORLD_SURFACE, ctx.getOrigin());
+        Direction offset = Direction.NORTH;
+
+        for (int y = 1; y <= 15; y++) {
+            offset = offset.rotateYClockwise();
+            world.setBlockState(topPos.up(y).offset(offset), Blocks.STONE.getDefaultState(), 3);
+        }
+        return true;
+    }
+
+    public static void generateShroom(WorldAccess world, Random random, BlockPos.Mutable pos, int minAge, int maxAge) {
+        // Assumes `pos` is air block
+        if (world.isAir(pos)) {
+            world.setBlockState(pos, ReverieObjects.SHROOM_BLOCK.getDefaultState().with(ShroomBlock.AGE, MathHelper.nextInt(random, minAge, maxAge)), Block.NOTIFY_LISTENERS);
+        }
+    }
+
+    private static boolean canGenerate(WorldAccess world, BlockPos.Mutable pos) {
+        // Don't generate at y=0
+        do {
+            pos.move(0, -1, 0);
+            if (world.isOutOfHeightLimit(pos)) {
+                return false;
+            }
+        } while(world.getBlockState(pos).isAir());
+
+        pos.move(0, 1, 0);
+        return true;
+    }
+
+    private static boolean isNotSuitable(WorldAccess world, BlockPos pos) {
+        // Not air, and one of the Nylium variants
+        if (!world.isAir(pos)) {
+            return true;
+        } else {
+            BlockState blockState = world.getBlockState(pos.down());
+            return !blockState.isIn(BlockTags.NYLIUM);
+        }
+    }
+
+//    @Override
+//    public boolean generate(StructureWorldAccess world, ChunkGenerator generator, Random random, BlockPos pos,
+//                            DefaultFeatureConfig config) {
+//        BlockPos topPos = world.getTopPosition(Heightmap.Type.WORLD_SURFACE, pos);
+//        Direction offset = Direction.NORTH;
+//
+//        for (int y = 1; y <= 15; y++) {
+//            offset = offset.rotateYClockwise();
+//            world.setBlockState(topPos.up(y).offset(offset), Blocks.STONE.getDefaultState(), 3);
+//        }
+//
+//        return true;
+//    }
+}

--- a/src/main/java/com/github/turtlelabsmc/reverie/item/ShroomItem.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/item/ShroomItem.java
@@ -1,0 +1,11 @@
+package com.github.turtlelabsmc.reverie.item;
+
+import net.minecraft.item.Item;
+
+public class ShroomItem extends Item {
+
+    public ShroomItem(Settings settings) {
+        super(settings);
+    }
+
+}

--- a/src/main/java/com/github/turtlelabsmc/reverie/registry/FeatureRegistry.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/registry/FeatureRegistry.java
@@ -1,0 +1,33 @@
+package com.github.turtlelabsmc.reverie.registry;
+
+import com.github.turtlelabsmc.reverie.Reverie;
+import com.github.turtlelabsmc.reverie.features.ShroomFeature;
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.fabricmc.fabric.impl.biome.modification.BiomeSelectionContextImpl;
+import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.biome.BiomeKeys;
+import net.minecraft.world.biome.BuiltinBiomes;
+import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.decorator.ChanceDecoratorConfig;
+import net.minecraft.world.gen.decorator.Decorator;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+import net.minecraft.world.gen.feature.FeatureConfig;
+
+public class FeatureRegistry {
+    public static final ShroomFeature SHROOM = new ShroomFeature(DefaultFeatureConfig.CODEC);
+    public static final ConfiguredFeature<?, ?> SHROOM_CONFIGURED = SHROOM.configure(FeatureConfig.DEFAULT)
+            .decorate(Decorator.CHANCE.configure(new ChanceDecoratorConfig(100)));
+
+    public static void register() {
+      Registry.register(Registry.FEATURE, Reverie.modId("shroom"), SHROOM);
+        RegistryKey<ConfiguredFeature<?,?>> shroom = RegistryKey.of(Registry.CONFIGURED_FEATURE_KEY, Reverie.modId("shroom"));
+      Registry.register(BuiltinRegistries.CONFIGURED_FEATURE, shroom.getValue(), SHROOM_CONFIGURED);
+
+        BiomeModifications.addFeature(BiomeSelectors.includeByKey(new RegistryKey[]{BiomeKeys.WARPED_FOREST, BiomeKeys.CRIMSON_FOREST}),
+                GenerationStep.Feature.UNDERGROUND_DECORATION, shroom);
+    }
+}

--- a/src/main/java/com/github/turtlelabsmc/reverie/registry/ReverieObjects.java
+++ b/src/main/java/com/github/turtlelabsmc/reverie/registry/ReverieObjects.java
@@ -1,0 +1,46 @@
+package com.github.turtlelabsmc.reverie.registry;
+
+import com.github.turtlelabsmc.reverie.Reverie;
+import com.github.turtlelabsmc.reverie.block.ShroomBlock;
+import com.github.turtlelabsmc.reverie.item.ShroomItem;
+import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.MapColor;
+import net.minecraft.block.Material;
+import net.minecraft.item.AliasedBlockItem;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ReverieObjects {
+
+    public static Map<Item, Identifier> ITEMS = new LinkedHashMap<>();
+    public static Map<Block, Identifier> BLOCKS = new LinkedHashMap<>();
+
+    private static Item.Settings withReverieGroup() {
+        return new Item.Settings().group(Reverie.ITEM_GROUP);
+    }
+
+    public static final Block SHROOM_BLOCK = create("shroom", new ShroomBlock(FabricBlockSettings.of(Material.SOLID_ORGANIC)), false);
+    public static final Item SHROOM = create("shroom", new AliasedBlockItem(SHROOM_BLOCK, withReverieGroup()));
+
+    private static <T extends Item> T create(String name, T item) {
+        ITEMS.put(item, Reverie.modId(name));
+        return item;
+    }
+    private static <T extends Block> T create(String name, T block, boolean withItem) {
+        BLOCKS.put(block, Reverie.modId(name));
+        if (withItem) ITEMS.put(new BlockItem(block, withReverieGroup()), BLOCKS.get(block));
+        return block;
+    }
+
+    public static void register() {
+        ITEMS.keySet().forEach(item -> Registry.register(Registry.ITEM, ITEMS.get(item), item));
+        BLOCKS.keySet().forEach(block -> Registry.register(Registry.BLOCK, BLOCKS.get(block), block));
+    }
+}


### PR DESCRIPTION
Changes:

* ++ Shroom Block and Item (no models/textures/lang files yet)
* ++ Reverie Item Group
* ++ Shroom worldgen feature (incomplete, but it does generate. Also generates a stone spiral so it's easier to find while in development)
* ++ (technical) `ReverieObjects.java` with registry code for blocks and items
* ++ (technical) `FeatureRegistry.java` with incomplete feature registry code.